### PR TITLE
Correct definition of module position

### DIFF
--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -63,7 +63,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_BOTTOM;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1;
 }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2744,7 +2744,7 @@ static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr)
   update_view(dr);
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 400;
 }

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -87,7 +87,7 @@ int expandable(dt_lib_module_t *self)
   return 1;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 900;
 }

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -71,7 +71,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 850;
 }

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -965,7 +965,7 @@ static void _style_changed(GtkWidget *widget, dt_lib_export_t *d)
   }
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 99;
 }

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -156,7 +156,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 450;
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -156,7 +156,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1000;
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -96,7 +96,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 900;
 }

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -284,7 +284,7 @@ static void _image_preference_changed(gpointer instance, gpointer user_data)
                            : _("physically delete from disk immediately"));
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 700;
 }

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -51,7 +51,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_RIGHT_BOTTOM;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 880;
 }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -579,8 +579,8 @@ gint dt_lib_sort_plugins(gconstpointer a, gconstpointer b)
 {
   const dt_lib_module_t *am = (const dt_lib_module_t *)a;
   const dt_lib_module_t *bm = (const dt_lib_module_t *)b;
-  const int apos = am->position ? am->position() : 0;
-  const int bpos = bm->position ? bm->position() : 0;
+  const int apos = am->position ? am->position(am) : 0;
+  const int bpos = bm->position ? bm->position(bm) : 0;
   return apos - bpos;
 }
 

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -77,7 +77,7 @@ OPTIONAL(int, button_pressed, struct dt_lib_module_t *self, double x, double y, 
                    uint32_t state);
 OPTIONAL(int, scrolled, struct dt_lib_module_t *self, double x, double y, int up);
 OPTIONAL(void, configure, struct dt_lib_module_t *self, int width, int height);
-OPTIONAL(int, position, );
+OPTIONAL(int, position, const struct dt_lib_module_t *self);
 
 /** implement these three if you want customizable presets to be stored in db. */
 /** legacy_params can run in iterations, just return to what version you updated the preset. */

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -119,7 +119,7 @@ void gui_reset(dt_lib_module_t *self)
   clear_search(lib);
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 999;
 }

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -68,7 +68,7 @@ typedef struct dt_loc_op_t
   char *oldtagname;
 } dt_loc_op_t;
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 995;
 }

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -56,7 +56,7 @@ typedef struct dt_lib_map_settings_t
   GtkWidget *images_thumb, *max_images_entry, *epsilon_factor, *min_images, *max_outline_nodes;
 } dt_lib_map_settings_t;
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 990;
 }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -66,7 +66,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 999;
 }

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -396,7 +396,7 @@ static gboolean _lost_focus(GtkWidget *textview, GdkEventFocus *event, dt_lib_mo
   return FALSE;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 510;
 }

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -182,7 +182,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_BOTTOM;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 999;
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -93,7 +93,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 999;
 }

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -78,7 +78,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1001;
 }

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -154,8 +154,7 @@ static void _height_changed(GtkWidget *widget, gpointer user_data);
 static void _x_changed(GtkWidget *widget, gpointer user_data);
 static void _y_changed(GtkWidget *widget, gpointer user_data);
 
-int
-position()
+int position(const dt_lib_module_t *self)
 {
   return 990;
 }

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -92,7 +92,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1000;
 }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -63,7 +63,7 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 599;
 }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2694,7 +2694,7 @@ void gui_reset(dt_lib_module_t *self)
   _update_atdetach_buttons(self);
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 500;
 }

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -61,7 +61,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1001;
 }

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -150,7 +150,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 2001;
 }

--- a/src/libs/tools/hinter.c
+++ b/src/libs/tools/hinter.c
@@ -58,7 +58,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1;
 }

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -75,7 +75,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1500;
 }

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -74,7 +74,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1001;
 }

--- a/src/libs/tools/mask_toolbar.c
+++ b/src/libs/tools/mask_toolbar.c
@@ -39,7 +39,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1000;
 }

--- a/src/libs/tools/menu.c
+++ b/src/libs/tools/menu.c
@@ -49,7 +49,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 2;
 }

--- a/src/libs/tools/menu_buttons.c
+++ b/src/libs/tools/menu_buttons.c
@@ -57,7 +57,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1;
 }

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -57,7 +57,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 1;
 }

--- a/src/libs/tools/module_toolbox.c
+++ b/src/libs/tools/module_toolbox.c
@@ -62,7 +62,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 100;
 }

--- a/src/libs/tools/view_toolbox.c
+++ b/src/libs/tools/view_toolbox.c
@@ -62,7 +62,7 @@ int expandable(dt_lib_module_t *self)
   return 0;
 }
 
-int position()
+int position(const dt_lib_module_t *self)
 {
   return 100;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2548,12 +2548,16 @@ void mouse_leave(dt_view_t *self)
   dt_control_set_mouse_over_id(dev->image_storage.id);
 
   // masks
-  if(dev->form_visible && dt_masks_events_mouse_leave(dev->gui_module));
+  gboolean handled = FALSE;
+  if(dev->form_visible && dt_masks_events_mouse_leave(dev->gui_module))
+    handled = TRUE;
   // module
   else if(dev->gui_module && dev->gui_module->mouse_leave
-          && dev->gui_module->mouse_leave(dev->gui_module));
+          && dev->gui_module->mouse_leave(dev->gui_module))
+    handled = TRUE;
 
-  dt_control_queue_redraw_center();
+  if(handled)
+    dt_control_queue_redraw_center();
 
   // reset any changes the selected plugin might have made.
   dt_control_change_cursor(GDK_LEFT_PTR);


### PR DESCRIPTION
Change module api from OPTIONAL(int, position, ); to OPTIONAL(int, position, const struct dt_lib_module_t *self);. This avoid compilation error claiming a missing prototyping: /.../github/ansel/src/lua/lib.c:92:38: fatal error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]. All modules using position have been updated.